### PR TITLE
Feature: Add Azure Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ celerybeat-schedule
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
 
 script:
   - black --check agipy/
-  - mypy agipy/
+  - mypy --ignore-missing-imports agipy/
   - pylint --errors-only agipy/
   - pytest agipy/

--- a/README.md
+++ b/README.md
@@ -13,3 +13,85 @@ to help you dissolving your cloud problems.
 `agipy` is a portmanteau of the chemical formula AgI for silver iodide and the word Python. Silver
 iodide is a chemical used for [cloud seeding](https://en.wikipedia.org/wiki/Cloud_seeding#Methodology)
 and [Python](https://www.python.org/) is the language `agipy` is implemented in.
+
+## How to use `agipy`
+
+To find out how the CLI works, use the built-in help function:
+
+```sh
+agipy --help
+```
+
+`agipy` is based on the concept of _providers_: For each public cloud provider, a `agipy`-specific
+provider module has to be implemented. At the moment, the following provider modules exist:
+
+* [Microsoft Azure](https://azure.microsoft.com/en-us/)
+
+Because each provider has its own semantics, please refer to the respective subsection.
+
+### How to use the `azure` provider
+
+As of yet, the `azure` provider is capable of deleting all resource groups with a specific prefix.
+For using the provider, you have to set the following environment variables:
+
+* `AZURE_CLIENT_ID`, the service principal ID
+* `AZURE_CLIENT_SECRET`, the service principal secret
+* `AZURE_SUBSCRIPTION_ID`
+* `AZURE_TENANT_ID`
+
+Then you can call the provider via:
+
+```sh
+agipy azure --prefix=${RG_PREFIX}
+```
+
+## How to Test
+
+The test suite is based on the great [`pytest`][1] library. Once installed, the automatic test
+discovery can be used via
+
+```sh
+pytest agipy
+```
+
+## How to Contribute
+
+This project is released under the GPL license because I opt for a wide acceptance rate. This also
+means that I am happy for contributions! This can be done on many ways:
+
+* Open PRs with improvements,
+* add issues if you find bugs,
+* add issues for new features,
+* use `agipy` and spread the word.
+
+PRs have to comply with:
+
+* [`black`](https://black.readthedocs.io/en/stable/),
+* [`mypy`](http://mypy-lang.org),
+* and [`pylint`](https://www.pylint.org).
+
+New features must be covered by proper tests (idealy unit tests and functional tests) using the [`pytest`][1] library.
+
+## Contributors
+
+* [shimst3r](https://twitter.com/shimst3r)
+
+## License
+
+> agipy enables you to destroy cloud infrastructure in a hurry.
+> Copyright (C) 2019  Nils Müller<shimst3r@gmail.com>
+>
+> This program is free software: you can redistribute it and/or modify
+> it under the terms of the GNU General Public License as published by
+> the Free Software Foundation, either version 3 of the License, or
+> (at your option) any later version.
+>
+> This program is distributed in the hope that it will be useful,
+> but WITHOUT ANY WARRANTY; without even the implied warranty of
+> MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+> GNU General Public License for more details.
+>
+> You should have received a copy of the GNU General Public License
+> along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+[1]: https://docs.pytest.org/en/latest/

--- a/agipy/agipy.py
+++ b/agipy/agipy.py
@@ -34,7 +34,7 @@ def interface(provider, prefix):
     interface is the entry point for the command line interface of agipy.
     """
     if provider == "azure":
-        from providers import azure
+        from agipy.providers import azure
 
         prov = azure.AzureProvider()
         prov.delete(prefix=prefix)

--- a/agipy/agipy.py
+++ b/agipy/agipy.py
@@ -20,7 +20,9 @@ import sys
 
 import click
 
-
+# pylint and Click do not work well together in all cases, see:
+# https://stackoverflow.com/questions/49680191/click-and-pylint
+# pylint: disable=no-value-for-parameter
 @click.command()
 @click.argument("provider", nargs=1, required=True)
 @click.option(

--- a/agipy/agipy.py
+++ b/agipy/agipy.py
@@ -16,9 +16,32 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>
 """
 
+import sys
 
-def interface():
+import click
+
+
+@click.command()
+@click.argument("provider", nargs=1, required=True)
+@click.option(
+    "-p",
+    "--prefix",
+    required=True,
+    help="The prefix of resource groups you want to delete.",
+)
+def interface(provider, prefix):
     """
     interface is the entry point for the command line interface of agipy.
     """
-    pass
+    if provider == "azure":
+        from providers import azure
+
+        prov = azure.AzureProvider()
+        prov.delete(prefix=prefix)
+    else:
+        click.echo(f"No provider package found for {provider}.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    interface()

--- a/agipy/providers/azure.py
+++ b/agipy/providers/azure.py
@@ -20,8 +20,8 @@ import os
 import sys
 
 import click
-from azure.common import credentials
-from azure.mgmt import resource
+from azure.common import credentials  # pylint: disable=no-name-in-module
+from azure.mgmt import resource  # pylint: disable=no-name-in-module
 from msrestazure.azure_exceptions import CloudError
 
 

--- a/agipy/providers/azure.py
+++ b/agipy/providers/azure.py
@@ -1,0 +1,113 @@
+"""
+agipy enables you to destroy cloud infrastructure in a hurry.
+Copyright (C) 2019  Nils Müller<shimst3r@gmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>
+"""
+import concurrent.futures
+import os
+import sys
+
+import click
+from azure.common import credentials
+from azure.mgmt import resource
+from msrestazure.azure_exceptions import CloudError
+
+
+class AzureProvider:
+    """
+    AzureProvider implements functionality to delete resources and resource
+    groups on Microsoft Azure's public cloud infrastructure.
+    """
+
+    def __init__(self):
+        self.client = self._setup_azure_client()
+
+    @property
+    def resource_groups(self):
+        """
+        resource_groups returns a list of resource groups for the given client.
+        """
+        return list(self.client.resource_groups.list())
+
+    def delete(self, prefix: str):
+        """
+        delete connects to the Azure public cloud and deletes all
+        resources and resource groups.
+        """
+        if not prefix:
+            click.echo("Cannot delete resource groups without empty prefix.")
+            sys.exit(1)
+        self._delete_resource_groups_by_prefix(prefix=prefix)
+
+    def _setup_azure_client(self) -> resource.ResourceManagementClient:
+        """
+        _setup_azure_client creates a ResourceManagementClient based on the
+        environment variables.
+        """
+        try:
+            client_id = os.environ["AZURE_CLIENT_ID"]
+            client_secret = os.environ["AZURE_CLIENT_SECRET"]
+            subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
+            tenant_id = os.environ["AZURE_TENANT_ID"]
+        except KeyError as error:
+            click.echo(error)
+            sys.exit(1)
+        else:
+            cred = credentials.ServicePrincipalCredentials(
+                client_id=client_id, secret=client_secret, tenant=tenant_id
+            )
+            client = resource.ResourceManagementClient(
+                credentials=cred, subscription_id=subscription_id
+            )
+
+            return client
+
+    def _delete_resource_group_by_name(self, rg_name: str):
+        """
+        _delete_resource_group_by_name deletes a resource group based on
+        its name.
+        """
+        awaitable = self.client.resource_groups.delete(rg_name)
+
+        try:
+            awaitable.wait()
+        except CloudError as error:
+            click.echo(error.message)
+        else:
+            click.echo(f"Succesfully deleted resource group {rg_name}.")
+
+    def _delete_resource_groups_by_prefix(self, prefix: str):
+        """
+        _delete_resource_groups_by_prefix deletes all resource groups for a
+        given subscription based on a given prefix.
+        """
+        deletables = [
+            rgx for rgx in self.resource_groups if rgx.name.startswith(prefix)
+        ]
+
+        if not deletables:
+            click.echo(f"Found no deletable resource groups for prefix {prefix}.")
+            return
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for rgx in deletables:
+                click.echo(
+                    f"Found deletable resource group {rgx.name}. Initialise deletion."
+                )
+                executor.submit(self._delete_resource_group_by_name, rgx.name)
+
+        click.echo(
+            f"Succesfully deleted {len(deletables)} resource groups for prefix {prefix}."
+        )

--- a/agipy/test_agipy.py
+++ b/agipy/test_agipy.py
@@ -28,3 +28,16 @@ def test_import_agipy_module():
         assert False
     else:
         assert True
+
+
+def test_import_azure_provider():
+    """
+    test_import_azure_provider makes sure the azure provider module can be
+    imported properly.
+    """
+    try:
+        from agipy.providers import azure
+    except ImportError:
+        assert False
+    else:
+        assert True

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 
 import m2r
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 ENTRY_POINTS = {"console_scripts": ["agipy = agipy.agipy:interface"]}
 
@@ -33,9 +33,12 @@ ENTRY_POINTS = {"console_scripts": ["agipy = agipy.agipy:interface"]}
 with open("README.md", "r", encoding="utf-8") as f_in:
     LONG_DESCRIPTION = m2r.convert(f_in.read())
 
-PACKAGES = ["agipy"]
+PACKAGES = ["agipy", "agipy.providers"]
 
-REQUIRES = ["azure", "Click"]
+REQUIRES = {
+    "azure": ["azure-common", "azure-mgmt-resource", "msrestazure"],
+    "general": ["Click"],
+}
 
 setup(
     author="Nils P. Müller",
@@ -51,7 +54,7 @@ setup(
     description="destroy cloud infrastructure in a hurry",
     download_url=f"https://github.com/shimst3r/agipy/archive/{__version__}.tar.gz",
     entry_points=ENTRY_POINTS,
-    install_requires=REQUIRES,
+    install_requires=[package for section in REQUIRES.values() for package in section],
     keywords=["azure", "cli", "cloud", "devops", "sysadmin", "tool"],
     license="GPL",
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
# Description

With this PR I add a provider for Microsoft Azure and the most basic command line interface you need for using the provider.

Furthermore I improve the README by adding usage examples and general information on the project.

## Note
Currently the `azure` provider needs environment variables to be set to work properly. In the future, several concepts for passing domain information will be evaluated, including `.env` files, command line arguments, and an interactive mode.