### PR TITLE
Improvement: Make provider subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ For using the provider, you have to set the following environment variables:
 * `AZURE_SUBSCRIPTION_ID`
 * `AZURE_TENANT_ID`
 
-Then you can call the provider via:
+Alternatively you can provide any of these values via command line arguments, see below.
+
+You can call the provider via:
 
 ```sh
-agipy azure --prefix=${RG_PREFIX}
+agipy azure --prefix=${RG_PREFIX} [--client-id=${AZURE_CLIENT_ID}] [--client-secret=${AZURE_CLIENT_SECRET}] [--subscription-id=${AZURE_SUBSCRIPTION_ID}] [--tenant-id=${AZURE_TENANT_ID}]
 ```
 
 ## How to Test
@@ -72,6 +74,8 @@ discovery can be used via
 ```sh
 pytest agipy
 ```
+
+In order to keep the tests clean and run smoothly, I try to use subtests and patches where possible.
 
 ## How to Contribute
 

--- a/agipy/agipy.py
+++ b/agipy/agipy.py
@@ -20,29 +20,19 @@ import sys
 
 import click
 
+from providers import azure
+
 # pylint and Click do not work well together in all cases, see:
 # https://stackoverflow.com/questions/49680191/click-and-pylint
 # pylint: disable=no-value-for-parameter
-@click.command()
-@click.argument("provider", nargs=1, required=True)
-@click.option(
-    "-p",
-    "--prefix",
-    required=True,
-    help="The prefix of resource groups you want to delete.",
-)
-def interface(provider, prefix):
+@click.group()
+def interface():
     """
-    interface is the entry point for the command line interface of agipy.
+    agipy enables you to destroy cloud infrastructure in a hurry
     """
-    if provider == "azure":
-        from agipy.providers import azure
 
-        prov = azure.AzureProvider()
-        prov.delete(prefix=prefix)
-    else:
-        click.echo(f"No provider package found for {provider}.")
-        sys.exit(1)
+
+interface.add_command(azure.azure)
 
 
 if __name__ == "__main__":

--- a/agipy/agipy.py
+++ b/agipy/agipy.py
@@ -15,12 +15,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>
 """
-
-import sys
-
 import click
 
-from providers import azure
+from .providers import azure
 
 # pylint and Click do not work well together in all cases, see:
 # https://stackoverflow.com/questions/49680191/click-and-pylint

--- a/agipy/providers/azure.py
+++ b/agipy/providers/azure.py
@@ -60,7 +60,7 @@ class AzureProvider:
     """
 
     def __init__(self):
-        self.client = self._setup_azure_client()
+        self.client = _setup_azure_client()
 
     @property
     def resource_groups(self):
@@ -76,29 +76,6 @@ class AzureProvider:
         """
 
         self._delete_resource_groups_by_prefix(prefix=prefix)
-
-    def _setup_azure_client(self) -> resource.ResourceManagementClient:
-        """
-        _setup_azure_client creates a ResourceManagementClient based on the
-        environment variables.
-        """
-        try:
-            client_id = os.environ["AZURE_CLIENT_ID"]
-            client_secret = os.environ["AZURE_CLIENT_SECRET"]
-            subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
-            tenant_id = os.environ["AZURE_TENANT_ID"]
-        except KeyError as error:
-            click.echo(f"azure provider is missing the {error}.")
-            sys.exit(1)
-        else:
-            cred = credentials.ServicePrincipalCredentials(
-                client_id=client_id, secret=client_secret, tenant=tenant_id
-            )
-            client = resource.ResourceManagementClient(
-                credentials=cred, subscription_id=subscription_id
-            )
-
-            return client
 
     def _delete_resource_group_by_name(self, rg_name: str):
         """
@@ -137,3 +114,27 @@ class AzureProvider:
         click.echo(
             f"Succesfully deleted {len(deletables)} resource groups for prefix {prefix}."
         )
+
+
+def _setup_azure_client() -> resource.ResourceManagementClient:
+    """
+    _setup_azure_client creates a ResourceManagementClient based on the
+    environment variables.
+    """
+    try:
+        client_id = os.environ["AZURE_CLIENT_ID"]
+        client_secret = os.environ["AZURE_CLIENT_SECRET"]
+        subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
+        tenant_id = os.environ["AZURE_TENANT_ID"]
+    except KeyError as error:
+        click.echo(f"azure provider is missing the {error}.")
+        sys.exit(1)
+    else:
+        cred = credentials.ServicePrincipalCredentials(
+            client_id=client_id, secret=client_secret, tenant=tenant_id
+        )
+        client = resource.ResourceManagementClient(
+            credentials=cred, subscription_id=subscription_id
+        )
+
+        return client

--- a/agipy/providers/test_azure.py
+++ b/agipy/providers/test_azure.py
@@ -46,6 +46,18 @@ def test_azure_without_environment_variables():
     assert actual == expected
 
 
+def test_azure_with_environment_variables():
+    _set_client_id()
+    _set_client_secret()
+    _set_subscription_id()
+    _set_tenant_id()
+
+    runner = click.testing.CliRunner()
+    actual = runner.invoke(azure.azure, args=["--prefix=test"])
+
+    assert actual.exit_code == 0
+
+
 def test_azure_with_permutations_of_missing_environment_variables(subtests):
     """
     This test case verifies that the azure provider will not run when at least

--- a/agipy/providers/test_azure.py
+++ b/agipy/providers/test_azure.py
@@ -16,28 +16,32 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>
 """
 
+import os
 
-def test_import_agipy_module():
-    """
-    test_import_agipy_module makes sure the agipy module can be imported 
-    properly.
-    """
-    try:
-        import agipy
-    except ImportError:
-        assert False
-    else:
-        assert True
+import click.testing
+
+from . import azure
 
 
-def test_import_azure_provider():
-    """
-    test_import_azure_provider makes sure the azure provider module can be
-    imported properly.
-    """
-    try:
-        from agipy.providers import azure
-    except ImportError:
-        assert False
-    else:
-        assert True
+def test_azure_without_prefix():
+    expected = (
+        "Usage: azure [OPTIONS]\n"
+        'Try "azure --help" for help.\n'
+        "\n"
+        'Error: Missing option "--prefix".\n'
+    )
+
+    runner = click.testing.CliRunner()
+    actual = runner.invoke(azure.azure, args=[]).output
+
+    assert actual == expected
+
+
+def test_azure_without_environment_variables():
+    expected = "azure provider is missing the 'AZURE_CLIENT_ID'.\n"
+
+    runner = click.testing.CliRunner()
+    actual = runner.invoke(azure.azure, args=["--prefix=test"]).output
+
+    assert actual == expected
+

--- a/agipy/providers/test_azure.py
+++ b/agipy/providers/test_azure.py
@@ -45,3 +45,47 @@ def test_azure_without_environment_variables():
 
     assert actual == expected
 
+
+def test_azure_with_permutations_of_missing_environment_variables(subtests):
+    """
+    This test case verifies that the azure provider will not run when at least
+    one of the necessary environment variables is not set if called without
+    additional command line arguments.
+    """
+    setup_funs = {
+        (_set_client_id, "AZURE_CLIENT_ID"),
+        (_set_client_secret, "AZURE_CLIENT_SECRET"),
+        (_set_subscription_id, "AZURE_SUBSCRIPTION_ID"),
+        (_set_tenant_id, "AZURE_TENANT_ID"),
+    }
+
+    for fun, env in setup_funs:
+        with subtests.test(msg=f"Testing without {env} being set"):
+            for setup_fun, _ in setup_funs - {fun}:
+                setup_fun()
+
+            del os.environ[env]
+
+            expected = f"azure provider is missing the '{env}'.\n"
+
+            runner = click.testing.CliRunner()
+            actual = runner.invoke(azure.azure, args=["--prefix=test"]).output
+
+            assert actual == expected
+
+
+def _set_client_id():
+    os.environ["AZURE_CLIENT_ID"] = "Azure_Client_Id"
+
+
+def _set_client_secret():
+    os.environ["AZURE_CLIENT_SECRET"] = "Azure_Client_Secret"
+
+
+def _set_subscription_id():
+    os.environ["AZURE_SUBSCRIPTION_ID"] = "Azure_Subscription_Id"
+
+
+def _set_tenant_id():
+    os.environ["AZURE_TENANT_ID"] = "Azure_Tenant_Id"
+

--- a/agipy/providers/test_azure.py
+++ b/agipy/providers/test_azure.py
@@ -24,6 +24,12 @@ import click.testing
 
 from . import azure
 
+# Some of the test cases use patching for mocking third party dependencies.
+# Because the unittest.mock.patch function expects those patched objects to
+# be present as (then unused) function arguments, this pylint warning will
+# be disabled.
+# pylint: disable=unused-argument
+
 EnvironmentVariable = namedtuple("EnvironmentVariable", ["env", "arg", "value"])
 
 ENV_VARS = [
@@ -39,6 +45,10 @@ ENV_VARS = [
 
 
 def test_azure_without_prefix():
+    """
+    This test case verifies that the azure provider will not run when no
+    prefix argument is provided.
+    """
     expected_exit_code = 2
     expected_output = (
         "Usage: azure [OPTIONS]\n"
@@ -57,6 +67,10 @@ def test_azure_without_prefix():
 
 
 def test_azure_without_environment_variables():
+    """
+    This test case verifies that the azure provider will not run when the
+    necessary environment variables are not set.
+    """
     expected_exit_code = 1
     expected_output = "azure provider is missing the 'AZURE_CLIENT_ID'.\n"
 
@@ -69,7 +83,7 @@ def test_azure_without_environment_variables():
 
 @patch("azure.common.credentials.ServicePrincipalCredentials")
 @patch("azure.mgmt.resource.ResourceManagementClient")
-def test_azure_with_prefix_and_environment_variables(credentials, client):
+def test_azure_with_prefix_and_environment_variables(cred, client):
     """
     This test case verifies that the azure provider will run properly if all
     necessary environment variables are set.
@@ -114,7 +128,7 @@ def test_azure_with_permutations_of_missing_environment_variables(subtests):
 
 @patch("azure.common.credentials.ServicePrincipalCredentials")
 @patch("azure.mgmt.resource.ResourceManagementClient")
-def test_azure_with_prefix_and_command_line_arguments(credentials, client):
+def test_azure_with_prefix_and_command_line_arguments(cred, client):
     """
     This test case verifies that the azure provider will run properly if all
     necessary command line arguments are provided.
@@ -159,9 +173,7 @@ def test_azure_without_env_vars_and_permutations_of_missing_arguments(subtests):
 
 @patch("azure.common.credentials.ServicePrincipalCredentials")
 @patch("azure.mgmt.resource.ResourceManagementClient")
-def test_azure_with_one_missing_env_var_and_related_argument(
-    credentials, client, subtests
-):
+def test_azure_with_one_missing_env_var_and_related_argument(cred, client, subtests):
     """
     This test case verifies that the azure provider will run properly if all
     but one environment variable is set and the missing value is provided

--- a/agipy/test_agipy.py
+++ b/agipy/test_agipy.py
@@ -16,10 +16,14 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>
 """
 
+# Most of the test cases in this test suite are about testing to import
+# submodules that will not be used.
+# pylint: disable=import-outside-toplevel, unused-import
+
 
 def test_import_agipy_module():
     """
-    test_import_agipy_module makes sure the agipy module can be imported 
+    test_import_agipy_module makes sure the agipy module can be imported
     properly.
     """
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ PyJWT==1.7.1
 pylint==2.4.3
 pyparsing==2.4.2
 pytest==5.2.1
+pytest-subtests==0.2.1
 python-dateutil==2.8.0
 readme-renderer==24.0
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 
 import m2r
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 ENTRY_POINTS = {"console_scripts": ["agipy = agipy.agipy:interface"]}
 


### PR DESCRIPTION
# Description

With this PR I implement the internal representation of providers. Before this PR, they are handled as arguments. After this PR, they will be handled as subcommands using `click.group() and `group.add_command()`.

## Note

This PR comes with a lot of additional test cases for the `azure` provider. I just learned how to use `unittest.mock.patch` and really like it. Please point out if I did anything wrong with those patches. :sweat_smile: 