### PR TITLE
Improvement: Add Python 3.6 and 3.8 to Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
+  - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.6-dev"
   - "3.7-dev"
   - "3.8-dev" 
   - "nightly" 


### PR DESCRIPTION
# Description

With this PR I add the "proper" Python 3.8 to the Travis configuration. In addition I decided to support Python 3.6 because why not. I don't need any funky >=3.7 features so far. :smile: 