### PR TITLE
Improvement: Add confirmation prompt

### DIFF
--- a/agipy/agipy.py
+++ b/agipy/agipy.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>
 """
 import click
 
-from providers import azure
+from .providers import azure
 
 # pylint and Click do not work well together in all cases, see:
 # https://stackoverflow.com/questions/49680191/click-and-pylint

--- a/agipy/agipy.py
+++ b/agipy/agipy.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>
 """
 import click
 
-from .providers import azure
+from providers import azure
 
 # pylint and Click do not work well together in all cases, see:
 # https://stackoverflow.com/questions/49680191/click-and-pylint

--- a/agipy/providers/azure.py
+++ b/agipy/providers/azure.py
@@ -31,6 +31,9 @@ from msrestazure.azure_exceptions import CloudError
 @click.option("--client-secret", required=False, help="Your Service Principal Secret")
 @click.option("--subscription-id", required=False, help="Your Subscription ID")
 @click.option("--tenant-id", required=False, help="Your Tenant ID")
+@click.confirmation_option(
+    prompt="Are you sure you want to delete all resource groups?"
+)
 def azure(prefix, client_id, client_secret, subscription_id, tenant_id):
     """
     azure is a command that lets you delete resource groups on
@@ -54,7 +57,8 @@ def azure(prefix, client_id, client_secret, subscription_id, tenant_id):
             subscription_id=subscription_id,
             tenant_id=tenant_id,
         )
-        provider.delete(prefix=prefix)
+
+    provider.delete(prefix=prefix)
 
 
 class AzureProvider:

--- a/agipy/providers/test_azure.py
+++ b/agipy/providers/test_azure.py
@@ -57,7 +57,7 @@ def test_azure_without_prefix():
         'Error: Missing option "--prefix".\n'
     )
 
-    args = []
+    args = ["--yes"]
 
     runner = click.testing.CliRunner()
     actual = runner.invoke(azure.azure, args=args)
@@ -74,8 +74,10 @@ def test_azure_without_environment_variables():
     expected_exit_code = 1
     expected_output = "azure provider is missing the 'AZURE_CLIENT_ID'.\n"
 
+    args = ["--prefix=test", "--yes"]
+
     runner = click.testing.CliRunner()
-    actual = runner.invoke(azure.azure, args=["--prefix=test"])
+    actual = runner.invoke(azure.azure, args=args)
 
     assert actual.exit_code == expected_exit_code
     assert actual.output == expected_output
@@ -94,7 +96,7 @@ def test_azure_with_prefix_and_environment_variables(cred, client):
     expected_exit_code = 0
     expected_output = f"Found no deletable resource groups for prefix test.\n"
 
-    args = ["--prefix=test"]
+    args = ["--prefix=test", "--yes"]
 
     with patch.dict(os.environ, {env.env: env.value for env in ENV_VARS}):
         runner = click.testing.CliRunner()
@@ -114,7 +116,7 @@ def test_azure_with_permutations_of_missing_environment_variables(subtests):
         expected_exit_code = 1
         expected_output = f"azure provider is missing the '{env_var.env}'.\n"
 
-        args = ["--prefix=test"]
+        args = ["--prefix=test", "--yes"]
         subset = {var.env: var.value for var in ENV_VARS if var != env_var}
 
         with patch.dict(os.environ, subset):
@@ -139,7 +141,9 @@ def test_azure_with_prefix_and_command_line_arguments(cred, client):
     expected_exit_code = 0
     expected_output = f"Found no deletable resource groups for prefix test.\n"
 
-    args = ["--prefix=test"] + [f"{env.arg}={env.value}" for env in ENV_VARS]
+    args = (
+        ["--prefix=test"] + [f"{env.arg}={env.value}" for env in ENV_VARS] + ["--yes"]
+    )
 
     with patch.dict(os.environ, {}):
         runner = click.testing.CliRunner()
@@ -161,7 +165,9 @@ def test_azure_without_env_vars_and_permutations_of_missing_arguments(subtests):
             expected_output = f"azure provider is missing the '{env_var.env}'.\n"
 
             subset = {var.arg: var.value for var in ENV_VARS if var != env_var}
-            args = ["--prefix=test"] + [f"{k}={v}" for k, v in subset.items()]
+            args = (
+                ["--prefix=test"] + [f"{k}={v}" for k, v in subset.items()] + ["--yes"]
+            )
 
             runner = click.testing.CliRunner()
             actual = runner.invoke(azure.azure, args=args)
@@ -189,7 +195,7 @@ def test_azure_with_one_missing_env_var_and_related_argument(cred, client, subte
             expected_exit_code = 0
             expected_output = f"Found no deletable resource groups for prefix test.\n"
 
-            args = ["--prefix=test", f"{env_var.arg}={env_var.value}"]
+            args = ["--prefix=test", f"{env_var.arg}={env_var.value}", "--yes"]
 
             runner = click.testing.CliRunner()
             actual = runner.invoke(azure.azure, args=args)
@@ -197,3 +203,4 @@ def test_azure_with_one_missing_env_var_and_related_argument(cred, client, subte
             with subtests.test(msg=f"Testing with {env_var} being set as argument"):
                 assert actual.exit_code == expected_exit_code
                 assert actual.output == expected_output
+

--- a/agipy/providers/test_azure.py
+++ b/agipy/providers/test_azure.py
@@ -203,4 +203,3 @@ def test_azure_with_one_missing_env_var_and_related_argument(cred, client, subte
             with subtests.test(msg=f"Testing with {env_var} being set as argument"):
                 assert actual.exit_code == expected_exit_code
                 assert actual.output == expected_output
-


### PR DESCRIPTION
# Description

With this PR I decorate the `azure` provider's entrypoint with a `click.confirmation_option`. This way the user either has to pass `--yes` as an additional command line flag, or has to confirm it interactively.